### PR TITLE
Version2

### DIFF
--- a/src/main/java/com/masonpohler/api/projects/Project.java
+++ b/src/main/java/com/masonpohler/api/projects/Project.java
@@ -3,8 +3,10 @@ package com.masonpohler.api.projects;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.masonpohler.api.source.Source;
 import lombok.Data;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,4 +38,7 @@ class Project {
             inverseJoinColumns = @JoinColumn(name = "source_id", referencedColumnName = "id")
     )
     private Set<Source> sources = new HashSet<>();
+
+    @UpdateTimestamp
+    private Date lastModified;
 }

--- a/src/main/java/com/masonpohler/api/projects/Project.java
+++ b/src/main/java/com/masonpohler/api/projects/Project.java
@@ -24,6 +24,7 @@ class Project {
     @Column(columnDefinition = "MEDIUMTEXT")
     private String detailedDescription;
 
+    private boolean large;
     private String previewURL;
     private String liveURL;
 

--- a/src/main/java/com/masonpohler/api/projects/ProjectController.java
+++ b/src/main/java/com/masonpohler/api/projects/ProjectController.java
@@ -44,8 +44,10 @@ class ProjectController {
         return repository.save(project);
     }
 
-    @PostMapping("/projects/delete")
-    void deleteProject(@RequestBody Project project) {
+    @DeleteMapping("/project/{id}/delete")
+    void deleteProject(@PathVariable long id) {
+        Project project = repository.findById(id)
+                .orElseThrow(() -> new ProjectNotFoundException(id));
         repository.delete(project);
     }
 }

--- a/src/main/java/com/masonpohler/api/projects/ProjectController.java
+++ b/src/main/java/com/masonpohler/api/projects/ProjectController.java
@@ -14,7 +14,7 @@ class ProjectController {
 
     @GetMapping("/projects")
     List<Project> getAllProjects() {
-        return repository.findAll();
+        return repository.findAllByOrderByLastModifiedDesc();
     }
 
     @GetMapping("/project/{id}")
@@ -44,7 +44,7 @@ class ProjectController {
         return repository.save(project);
     }
 
-    @DeleteMapping("/projects/delete")
+    @PostMapping("/projects/delete")
     void deleteProject(@RequestBody Project project) {
         repository.delete(project);
     }

--- a/src/main/java/com/masonpohler/api/projects/ProjectRepository.java
+++ b/src/main/java/com/masonpohler/api/projects/ProjectRepository.java
@@ -2,5 +2,8 @@ package com.masonpohler.api.projects;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 interface ProjectRepository extends JpaRepository<Project, Long> {
+    List<Project> findAllByOrderByLastModifiedDesc();
 }

--- a/src/main/java/com/masonpohler/api/security/WebSecurityConfig.java
+++ b/src/main/java/com/masonpohler/api/security/WebSecurityConfig.java
@@ -28,6 +28,7 @@ class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                     .antMatchers("/login").permitAll()
                     .antMatchers(HttpMethod.GET, "/**").permitAll()
+                    .antMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .anyRequest().hasAuthority(Authorities.ADMIN.toString());
     }
 }

--- a/src/main/java/com/masonpohler/api/source/SourceController.java
+++ b/src/main/java/com/masonpohler/api/source/SourceController.java
@@ -27,8 +27,10 @@ class SourceController {
         return repository.save(source);
     }
 
-    @DeleteMapping("sources/delete")
-    void deleteSource(@RequestBody Source source) {
+    @DeleteMapping("source/{id}/delete")
+    void deleteSource(@PathVariable long id) {
+        Source source = repository.findById(id)
+                .orElseThrow(() -> new SourceNotFoundException(id));
         repository.delete(source);
     }
 }

--- a/src/test/java/com/masonpohler/api/projects/ProjectControllerTest.java
+++ b/src/test/java/com/masonpohler/api/projects/ProjectControllerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 
+import java.sql.Date;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -211,6 +212,7 @@ class ProjectControllerTest {
     void delete_project_removes_project_from_repository() {
         List<Project> dummyProjectList = createDummyProjectList();
         mockFindAll(dummyProjectList);
+        mockFindById(dummyProjectList);
         mockDelete(dummyProjectList);
 
         Project dummyProject = dummyProjectList.get(0);
@@ -218,7 +220,7 @@ class ProjectControllerTest {
         List<Project> expectedProjectList = new LinkedList<>(dummyProjectList);
         expectedProjectList.remove(dummyProject);
 
-        controller.deleteProject(dummyProject);
+        controller.deleteProject(dummyProject.getId());
         List<Project> actualProjectList = mockedRepository.findAll();
 
         assertEquals(expectedProjectList, actualProjectList);
@@ -228,6 +230,7 @@ class ProjectControllerTest {
 
     private void mockFindAll(List<Project> projectList) {
         when(mockedRepository.findAll()).thenReturn(projectList);
+        when(mockedRepository.findAllByOrderByLastModifiedDesc()).thenReturn(projectList);
     }
 
     private void mockFindById(List<Project> projectList) {
@@ -264,6 +267,7 @@ class ProjectControllerTest {
         dummyProject.setDetailedDescription("An API for storing information on all your Projects.");
         dummyProject.setPreviewURL("https://example.com/projects-api/image.jpg");
         dummyProject.setLiveURL("https://example.com/projects-api");
+        dummyProject.setLastModified(Date.valueOf("2020-06-17"));
         return dummyProject;
     }
 
@@ -275,6 +279,7 @@ class ProjectControllerTest {
         meatbol.setDetailedDescription("An interpreter for the Meatbol language.");
         meatbol.setPreviewURL("https://example.com/meatbol/image.jpg");
         meatbol.setLiveURL("https://example.com/meatbol");
+        meatbol.setLastModified(Date.valueOf("2020-06-20"));
 
         Project pcWonder = new Project();
         pcWonder.setId(1);
@@ -283,6 +288,7 @@ class ProjectControllerTest {
         pcWonder.setDetailedDescription("An ecommerce website for computer hardware.");
         pcWonder.setPreviewURL("https://example.com/pc-wonder/image.jpg");
         pcWonder.setLiveURL("https://example.com/pc-wonder");
+        pcWonder.setLastModified(Date.valueOf("2020-06-19"));
 
         Project portfolio = new Project();
         portfolio.setId(2);
@@ -291,6 +297,7 @@ class ProjectControllerTest {
         portfolio.setDetailedDescription("This is my Portfolio.");
         portfolio.setPreviewURL("https://example.com/portfolio/image.jpg");
         portfolio.setLiveURL("https://example.com/portfolio");
+        portfolio.setLastModified(Date.valueOf("2020-06-18"));
 
         List<Project> dummyProjectsList = new LinkedList<>();
         dummyProjectsList.add(meatbol);

--- a/src/test/java/com/masonpohler/api/source/SourceControllerTest.java
+++ b/src/test/java/com/masonpohler/api/source/SourceControllerTest.java
@@ -100,13 +100,14 @@ class SourceControllerTest {
     void delete_source_removes_source_from_repository() {
         List<Source> dummySourceList = createDummySourceList();
         mockFindAll(dummySourceList);
+        mockFindById(dummySourceList);
         mockDelete(dummySourceList);
 
         Source dummySource = dummySourceList.get(0);
         List<Source> expectedSourceList = new LinkedList<>(dummySourceList);
         expectedSourceList.remove(dummySource);
 
-        controller.deleteSource(dummySource);
+        controller.deleteSource(dummySource.getId());
         List<Source> actualSourceList = mockedRepository.findAll();
 
         assertEquals(expectedSourceList, actualSourceList);


### PR DESCRIPTION
Version 2 of the Projects API comes with changes to previously implemented features. These changes include:

- Projects returned by GET /projects will now be ordered by last modified descending
- Projects contain a boolean marking whether they are large projects or not
- WebSecurityConfig now permits all OPTIONS requests
- Deletion endpoints now use an ID rather than an object
- Project Deletion endpoints have been moved from DELETE /projects/delete to DELETE /project/{id}/delete
- Source Deletion endpoints have been moved from DELETE /sources/delete to DELETE /source/{id}/delete

Version 2 of the Projects API will be deployed to https://api.masonpohler.com:1000